### PR TITLE
Add DEBIAN_FRONTEND=noninteractive to example Dockerfiles

### DIFF
--- a/example-problems/custom-ssh/Dockerfile
+++ b/example-problems/custom-ssh/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3
 
 
 # Install challenge dependencies within the image
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     openssh-server \
     socat \
     python3

--- a/example-problems/custom-ssh/Dockerfile.test
+++ b/example-problems/custom-ssh/Dockerfile.test
@@ -5,7 +5,7 @@ FROM ubuntu@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3
 
 
 # Install challenge dependencies within the image
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     openssh-server \
     socat \
     python3

--- a/example-problems/custom-web/Dockerfile
+++ b/example-problems/custom-web/Dockerfile
@@ -3,7 +3,7 @@ FROM nginx@sha256:1c13bc6de5dfca749c377974146ac05256791ca2fe1979fc8e8278bf0121d2
 
 
 # Install challenge dependencies within the image
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3
 
 

--- a/example-problems/custom-web/Dockerfile.old
+++ b/example-problems/custom-web/Dockerfile.old
@@ -3,7 +3,7 @@ FROM httpd:2.4
 
 
 # Install challenge dependencies within the image
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3
 
 


### PR DESCRIPTION
To demonstrate best practices when installing packages.